### PR TITLE
Update runtime versions and optimise dotnet implementation

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.14.3
 
 WORKDIR /go/src/app
 COPY . .

--- a/api/main.go
+++ b/api/main.go
@@ -17,19 +17,18 @@ type Response struct {
 }
 
 func main() {
+	rsp := Response{
+		Id:   "id_" + strconv.Itoa(rand.Int()),
+		Name: "name_" + strconv.Itoa(rand.Int()),
+		Time: time.Now().Unix(),
+	}
+
+	js, err := json.Marshal(rsp)
+	if err != nil {
+		panic(err)
+		return
+	}
 	http.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
-		rsp := Response{
-			Id:   "id_" + strconv.Itoa(rand.Int()),
-			Name: "name_" + strconv.Itoa(rand.Int()),
-			Time: time.Now().Unix(),
-		}
-
-		js, err := json.Marshal(rsp)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(js); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.14.3
 
 WORKDIR /go/src/app
 COPY . .

--- a/netcore/Dockerfile
+++ b/netcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 WORKDIR /dotnetapp
 

--- a/netcore/Program.cs
+++ b/netcore/Program.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 class Program
@@ -82,7 +76,8 @@ class Startup
 
         app.Run(async ctx =>
         {
-            await ctx.Response.WriteAsync($"Hello, {ctx.Request.Path}");
+            //await ctx.Response.WriteAsync($"Hello, {ctx.Request.Path}");
+            await ctx.Response.WriteAsync("updated");
         });
     }
 }

--- a/netcore/netcore.csproj
+++ b/netcore/netcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,8 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/netcore/netcore.csproj
+++ b/netcore/netcore.csproj
@@ -9,11 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+    <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update dotnet to version 3.1 and Go to version 1.14.3.

Avoid intermediate objects while serializing and deserializing to reduce the heap allocations, and use struct instead of class in the dotnet implementation.

While I was doing the stress test after the optimization I noticed that most of the time was taking generating the message for the `/data` endpoint, because of this I changed the logic to serialize just one time to have some dummy data.

Benchmarks results:

**Dotnet before the changes**

```
  8 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    49.17ms   86.91ms   1.14s    98.00%
    Req/Sec   798.61    124.90     1.21k    69.75%
  Latency Distribution
     50%   36.99ms
     75%   43.43ms
     90%   51.69ms
     99%  590.06ms
  626113 requests in 1.67m, 135.40MB read
  Socket errors: connect 13, read 102, write 0, timeout 0
Requests/sec:   6254.80
Transfer/sec:      1.35MB
```

**Golang before the changes**
```
Running 2m test @ http://localhost:5001
  8 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    56.06ms   30.16ms   1.17s    81.73%
    Req/Sec   548.10     84.68     0.85k    67.60%
  Latency Distribution
     50%   62.04ms
     75%   71.72ms
     90%   81.10ms
     99%  114.05ms
  436658 requests in 1.67m, 79.44MB read
  Socket errors: connect 13, read 103, write 0, timeout 0
Requests/sec:   4364.08
Transfer/sec:    812.97KB
```

**Dotnet after the changes**
```
Running 2m test @ http://localhost:5000
  8 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    30.28ms   35.15ms   1.09s    94.93%
    Req/Sec     1.12k   188.25     1.88k    67.12%
  Latency Distribution
     50%   25.10ms
     75%   31.83ms
     90%   46.77ms
     99%  116.81ms
  893070 requests in 1.67m, 193.34MB read
  Socket errors: connect 13, read 94, write 0, timeout 0
Requests/sec:   8926.08
Transfer/sec:      1.93MB
```

**Golang after the changes**
```
Running 2m test @ http://localhost:5001
  8 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    45.05ms   40.56ms 769.86ms   90.90%
    Req/Sec   720.72    117.90     1.12k    69.50%
  Latency Distribution
     50%   41.56ms
     75%   58.78ms
     90%   73.43ms
     99%  117.75ms
  571204 requests in 1.67m, 104.05MB read
  Socket errors: connect 13, read 98, write 0, timeout 0
Requests/sec:   5708.86
Transfer/sec:      1.04MB
```